### PR TITLE
Improve the friendliness of the TBD REPL UI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## What is it?
-_TBD_ (Tiny Bash Debugger) is a simple debugger for Bash that can be used to
+_TBD_ (Tmux Bash Debugger) is a simple debugger for Bash that can be used to
 interactively inspect or debug the execution of a Bash script. It's meant to be
 `source`'ed into your script at the place where you want a break point to be set.
 Once at the break point, _TBD_ will take over and run in a separate _tmux_ window,

--- a/tbd-view
+++ b/tbd-view
@@ -61,7 +61,7 @@ view-source-pane () {
         while true; do
             file=$(cat "$pipe") && fifo-ack "$pipe"
             read -t2 -r from to < "$pipe" && fifo-ack "$pipe"
-            bat --color always \
+            bat --color always ${NO_COLOR:+--color never} \
                 --highlight-line "$from:${to:-$from}" "$file" \
                 | less -K -RX +${from}g
         done
@@ -74,6 +74,7 @@ set -eo pipefail
 
 $(declare -f fifo-ack)
 $(declare -f source-viewer)
+$(if [[ ${NO_COLOR:-} ]]; then echo export NO_COLOR=x; fi)
 
 trap 'rm -f "\$0"' EXIT
 
@@ -93,6 +94,7 @@ cat > "$repl_script" <<EOF
 set -e
 
 $(declare -p tbd_pid prompt_prefix tbd_pipe view_pipe window_id)
+$(if [[ ${NO_COLOR:-} ]]; then echo export NO_COLOR=x; fi)
 
 $(declare -f fifo-ack)
 $(declare -f view-source-pane)


### PR DESCRIPTION
- `/help` now shows bat rendered markdown.
- The current / next command to be executed is now also rendered with bat.
- Add colors to the REPL prompt and command exit status.